### PR TITLE
Added #ifndef RSHT_NO_INCLUDES to rsht.h to prevent double-inclusion …

### DIFF
--- a/rsht.h
+++ b/rsht.h
@@ -13,8 +13,10 @@
 #ifndef RSHT_H
 #define RSHT_H
 
+#ifndef RSHT_NO_INCLUDES
 #include <stdbool.h>
 #include <stddef.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/rsht.c
+++ b/src/rsht.c
@@ -10,10 +10,12 @@
  * WITHOUT ANY WARRANTY. See the LICENSE file for more details.
  */
 
+#ifdef RSHT_NO_INCLUDES
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 #include "../rsht.h"
+#endif
 
 #ifndef RSHT_CAPACITY_SCALE
 #define RSHT_CAPACITY_SCALE 1.5


### PR DESCRIPTION
…of standard library headers.