### PR TITLE
Add explicit casts to *alloc and djb2 calls

### DIFF
--- a/src/rsht.c
+++ b/src/rsht.c
@@ -34,7 +34,7 @@ static unsigned long djb2(const unsigned char *str) {
 
 // bool: did it work?
 static bool setcapacity(rsht_ht *ht, const size_t capacity) {
-  rsht_entry *items = realloc(ht->items, capacity * sizeof(rsht_entry));
+  rsht_entry *items = (rsht_entry *)realloc(ht->items, capacity * sizeof(rsht_entry));
   if (!items) {
     return false;
   }
@@ -46,7 +46,7 @@ static bool setcapacity(rsht_ht *ht, const size_t capacity) {
 // hint: only rsht_create should call this, and only once.
 // bool: did it work?
 static bool makebuckets(rsht_ht *ht, const size_t num_buckets) {
-  size_t *buckets = calloc(num_buckets, sizeof(size_t));
+  size_t *buckets = (size_t *)calloc(num_buckets, sizeof(size_t));
   if (!buckets) {
     return false;
   }
@@ -111,11 +111,11 @@ rsht_entry *rsht_get_hash(const rsht_ht *ht, const char *key, const unsigned lon
 }
 
 rsht_entry *rsht_get(const rsht_ht *ht, const char *key) {
-  return rsht_get_hash(ht, key, djb2(key));
+  return rsht_get_hash(ht, key, djb2((const unsigned char *)key));
 }
 
 bool rsht_put(rsht_ht *ht, char *key, void *val, void **old_val_ref) {
-  const unsigned long hash = djb2(key);
+  const unsigned long hash = djb2((const unsigned char *)key);
   rsht_entry *entry = rsht_get_hash(ht, key, hash);
   if (entry) { // if we found it, swap the value into the entry
     if (old_val_ref)


### PR DESCRIPTION
The `void *` return value of realloc and calloc needs to be explicitly cast for C++ compliance. The djb2 function takes `const unsigned char *` as input, but a `char *` is passed, so we need to explicitly cast it for C++ compliance.